### PR TITLE
New call autocomplete

### DIFF
--- a/app/views/layouts/partials/_floatingForm.erb
+++ b/app/views/layouts/partials/_floatingForm.erb
@@ -1,11 +1,22 @@
       
       <%= form_tag("/submit_form", method: "post") do %>
 
+      <script>
+     $( function() {
+       $( "#countyMatch" ).autocomplete({
+         source: '<%= counties_path(:json) %>'
+       });
+       $( "#itemMatch" ).autocomplete({
+         source: '<%= items_path(:json) %>'
+       });
+     } );
+</script>
+
       County
-      <%= select_tag 'county', options_for_select(County.all.alphabetical.map { |a| [a.name, a.id]}, @vals[0]), :required => true %>
+      <%= text_field_tag :county, params[:county], :placeholder => 'Enter County', id:'countyMatch', :required => true %>
 
       Item
-      <%= select_tag 'item', options_for_select(Item.all.alphabetical.map { |a| [a.name.capitalize, a.id]}, @vals[1]), :required => true %>
+      <%= text_field_tag :item, params[:item], :placeholder => 'Enter Item', id:'itemMatch', :required => true %>
 
       Caller Name
       <%= text_field_tag :callerName, @vals[2] %>

--- a/app/views/main/index.html.erb
+++ b/app/views/main/index.html.erb
@@ -1,9 +1,9 @@
 <script>
      $( function() {
-       $( "#counties" ).autocomplete({
+       $( "#countyList" ).autocomplete({
          source: '<%= counties_path(:json) %>'
        });
-       $( "#items" ).autocomplete({
+       $( "#itemList" ).autocomplete({
          source: '<%= items_path(:json) %>'
        });
      } );
@@ -21,8 +21,8 @@
 
      <h4> <%= @errors %> </h4>
      <%= form_tag("", :method => "get", id: "search-form") do %>
-     <%= text_field_tag :item, params[:item], :placeholder => 'Enter Item', id:'items' %>
-     <%= text_field_tag :county, params[:county], :placeholder => 'Enter County', id:'counties' %>
+     <%= text_field_tag :item, params[:item], :placeholder => 'Enter Item', id:'itemList' %>
+     <%= text_field_tag :county, params[:county], :placeholder => 'Enter County', id:'countyList' %>
 
      <%= text_field_tag :zip, params[:zip], placeholder: "Zipcodes", maxlength: 5, class: 'input-small' %>
      <%= submit_tag "Search", :name => nil, class: "button" %>


### PR DESCRIPTION
Okay, I got autocomplete working in the search and new call form. The way autocomplete is set up it doesn't allow id's to pass. I haven't followed the new call process and don't want to mess anything up, but you'll have to match search's process of finding the id from the input name.